### PR TITLE
Fixed #12003 - new API for refresh_facts action

### DIFF
--- a/lib/smart_proxy_discovery_image/http_config.ru
+++ b/lib/smart_proxy_discovery_image/http_config.ru
@@ -1,5 +1,10 @@
 require 'smart_proxy_discovery_image/power_api'
+require 'smart_proxy_discovery_image/inventory_api'
 
 map "/power" do
   run Proxy::DiscoveryImage::PowerApi
+end
+
+map "/inventory" do
+  run Proxy::DiscoveryImage::InventoryApi
 end

--- a/lib/smart_proxy_discovery_image/inventory_api.rb
+++ b/lib/smart_proxy_discovery_image/inventory_api.rb
@@ -1,0 +1,13 @@
+class Proxy::DiscoveryImage::InventoryApi < Sinatra::Base
+  helpers ::Proxy::Helpers
+
+  get "/facter" do
+    begin
+      content_type :json
+      Facter.clear
+      Facter.to_hash.to_json
+    rescue => e
+      log_halt 400, e
+    end
+  end
+end


### PR DESCRIPTION
@stbenjam This is the last series of patches. Since fdi 3.0+ now listens on
HTTPS by default, we no longer can leverage the standard Smart Proxy Facts
API which requires SSL client auth.

This series (plugin, image, proxy-proxy, proxy-image) adds new API which I
named "inventory_api" not to confuse with original "facts_api".