### PR TITLE
Catch JSON parsing error correctly

### DIFF
--- a/lib/smart_proxy_discovery_image/power_api.rb
+++ b/lib/smart_proxy_discovery_image/power_api.rb
@@ -7,16 +7,21 @@ module Proxy::DiscoveryImage
     include Proxy::Util
 
     put "/reboot" do
-      log_halt 500, "shutdown binary was not found" unless (shutdown = which('shutdown'))
+      log_halt(500, "shutdown binary was not found") unless (shutdown = which('shutdown'))
       run_after_response 5, shutdown, "-r", "now", "Foreman Power API reboot"
       content_type :json
       { :result => true }.to_json
     end
 
     put "/kexec" do
-      log_halt 500, "kexec binary was not found" unless (kexec = which('kexec'))
-      data = JSON.parse request.body.read
-
+      body_data = request.body.read
+      logger.debug "Initiated kexec provisioning with #{body_data}"
+      log_halt(500, "kexec binary was not found") unless (kexec = which('kexec'))
+      begin
+        data = JSON.parse body_data
+      rescue JSON::ParserError
+        log_halt 500, "Unable to parse kexec JSON input: #{body_data}"
+      end
       logger.debug "Downloading: #{data['kernel']}"
       if ::Proxy::HttpDownload.new(data['kernel'], '/tmp/vmlinuz').start.join != 0
         log_halt 500, "cannot download kernel for kexec!"
@@ -33,7 +38,7 @@ module Proxy::DiscoveryImage
     # Execute command in a separate thread after 5 seconds to give the server some
     # time to finish the request. Does *not* execute via a shell.
     def run_after_response(seconds, *command)
-      logger.debug "Power API command scheduled in #{seconds} seconds"
+      logger.debug "Power API scheduling in #{seconds} seconds: #{command.inspect}"
       Thread.start do
         begin
           sleep seconds


### PR DESCRIPTION
Previously we let JSON parsing errors to bubble up to generic 500 without any message. It's now more clear what happened.