### PR TITLE
Refs #20548 - change virtual terminal during kexec

### DIFF
--- a/lib/smart_proxy_discovery_image/power_api.rb
+++ b/lib/smart_proxy_discovery_image/power_api.rb
@@ -15,6 +15,8 @@ module Proxy::DiscoveryImage
 
     put "/kexec" do
       body_data = request.body.read
+      # change virtual terminal out of newt screen
+      system("chvt, "2")
       logger.debug "Initiated kexec provisioning with #{body_data}"
       log_halt(500, "kexec binary was not found") unless (kexec = which('kexec'))
       begin
@@ -30,7 +32,7 @@ module Proxy::DiscoveryImage
       if ::Proxy::HttpDownload.new(data['initram'], '/tmp/initrd.img').start.join != 0
         log_halt 500, "cannot download initram for kexec!"
       end
-      run_after_response 2, kexec, "--force", "--reset-vga", "--append=#{data['append']}", "--initrd=/tmp/initrd.img", "/tmp/vmlinuz", *data['extra']
+      run_after_response 2, kexec, "--debug", "--force", "--reset-vga", "--append=#{data['append']}", "--initrd=/tmp/initrd.img", "/tmp/vmlinuz", *data['extra']
       { :result => true }.to_json
     end
 


### PR DESCRIPTION
This change needs

https://github.com/theforeman/foreman-discovery-image/pull/96

to be present. To test this either build the image with updated RPM or copy the changed file onto the discovered node and restart foreman-proxy and then test:

1) Boot from USB into PXE-less mode
2) Discover the nost
3) Apply this patch and restart proxy
4) Initiate provisioning

Without this change, node stays on the TUI and text is broken. With this patch, before kexec temrinal is chanded to tty2 (journald log) and Anaconda is showed correctly.