### PR TITLE
Fixes #30575 - fix power API

### DIFF
--- a/lib/smart_proxy_discovery_image/power_api.rb
+++ b/lib/smart_proxy_discovery_image/power_api.rb
@@ -24,36 +24,23 @@ module Proxy::DiscoveryImage
       rescue JSON::ParserError
         log_halt 500, "Unable to parse kexec JSON input: #{body_data}"
       end
-      run_after_response data, 2, kexec, "--debug", "--force", "--append=#{data['append']}", "--initrd=/tmp/initrd.img", "/tmp/vmlinuz", *data['extra']
+      download_and_run_after_response data, 2, kexec, "--debug", "--force", "--append=#{data['append']}", "--initrd=/tmp/initrd.img", "/tmp/vmlinuz", *data['extra']
       { :result => true }.to_json
     end
 
 
     # Execute command in a separate thread after 5 seconds to give the server some
     # time to finish the request. Does *not* execute via a shell.
-    def run_after_response(data, seconds, *command)
+    def run_after_response(seconds, *command)
       Thread.start do
         begin
-          # download kernel and initramdisk
-          logger.debug "Downloading: #{data['kernel']}"
-          vmlinuz_thread = ::Proxy::HttpDownload.new(data['kernel'], '/tmp/vmlinuz').start
-          logger.error("vmlinuz is still downloading, ignored") unless vmlinuz_thread
-          logger.error("cannot download vmlinuz for kexec") unless vmlinuz_thread.join == 0
-          logger.debug "Downloading: #{data['initram']}"
-          initrd_thread = ::Proxy::HttpDownload.new(data['initram'], '/tmp/initrd.img').start
-          logger.error("initrd.img is still downloading, ignored") unless initrd_thread
-          logger.error("cannot download initrd.img for kexec") unless initrd_thread.join == 0
-          # wait few seconds just in case the download was fast and perform kexec
-          # only perform kexec when both locks were available to prevent subsequent request while downloading
-          if vmlinuz_thread && initrd_thread
-            logger.debug "Power API scheduling in #{seconds} seconds: #{command.inspect}"
-            sleep seconds
-            logger.debug "Power API executing: #{command.inspect}"
-            if (sudo = which('sudo'))
-              status = system(sudo, *command)
-            else
-              logger.warn "sudo binary was not found"
-            end
+          logger.debug "Power API scheduling in #{seconds} seconds: #{command.inspect}"
+          sleep seconds
+          logger.debug "Power API executing: #{command.inspect}"
+          if (sudo = which('sudo'))
+            status = system(sudo, *command)
+          else
+            logger.warn "sudo binary was not found"
           end
           # only report errors
           logger.warn "The attempted command failed with code #{$?.exitstatus}" unless status
@@ -61,6 +48,33 @@ module Proxy::DiscoveryImage
           logger.error "Error during command execution: #{e}"
         end
       end
+    end
+
+    # Variant which also downloads kernel and initramdisk
+    def download_and_run_after_response(data, seconds, *command)
+      Thread.start do
+        begin
+          # download kernel and initramdisk
+          downloaded = download_file(data, 'kernel', 'vmlinuz', '/tmp') &&
+                         download_file(data, 'initram', 'initrd.img', '/tmp')
+          # wait few seconds just in case the download was fast and perform kexec
+          # only perform kexec when both locks were available to prevent subsequent request while downloading
+          run_after_response(seconds, *command) if downloaded
+        rescue Exception => e
+          logger.error "Error during command execution: #{e}"
+        end
+      end
+    end
+
+    def download_file(data, kind, name, prefix)
+      return unless data && (url = data[kind])
+
+      logger.debug "Downloading: #{url}"
+      download_thread = ::Proxy::HttpDownload.new(url, File.join(prefix, name)).start
+      logger.error("#{name} is still downloading, ignored") unless download_thread
+      download_success = download_thread.join.zero?
+      logger.error("cannot download #{name} for kexec") unless download_success
+      download_success
     end
   end
 end


### PR DESCRIPTION
The previous commit broke both reboot and kexec. This fixes it.

To test this, boot a FDI image, ssh to it and copy this file over:

```
sshpass -p redhat scp % root@192.168.199.11:/opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_discovery_image-1.2.0/lib/smart_proxy_discovery_image/power_api.rb
```

Then restart the `foreman-proxy` service and use this from Foreman or:

```
curl -X PUT -k -H 'Accept: application/json,version=2' -H 'Content-Type: application/json' -i 'http://192.168.199.11:8448/power/reboot' --data ''
```

and

```
curl -X PUT -k -H 'Accept: application/json,version=2' -H 'Content-Type: application/json' -i 'http://192.168.199.11:8448/power/kexec' --data '{"kernel": "http://192.168.199.1/rh/rhel-7-server-kickstart/7.7/images/pxeboot/vmlinuz", "initram": "http://192.168.199.1/rh/rhel-7-server-kickstart/7.7/images/pxeboot/initrd.img"}'
```