### PR TITLE
Remove --reset-vga, was added back in when PR12 was merged

### DIFF
--- a/lib/smart_proxy_discovery_image/power_api.rb
+++ b/lib/smart_proxy_discovery_image/power_api.rb
@@ -26,7 +26,7 @@ module Proxy::DiscoveryImage
       rescue JSON::ParserError
         log_halt 500, "Unable to parse kexec JSON input: #{body_data}"
       end
-      args = ["--debug", "--force", "--reset-vga"]
+      args = ["--debug", "--force"]
       args << data['extra'] if data['extra']
       args << "--kexec-file-syscall" if is_secureboot
       args << "--append=#{data['append']}"


### PR DESCRIPTION
--reset-vga was removed in PR  #8 but added back in PR #12, causes display issues with EFI.