### PR TITLE
Fixes #31519 - extra JSON kexec argument fixed

### DIFF
--- a/lib/smart_proxy_discovery_image/power_api.rb
+++ b/lib/smart_proxy_discovery_image/power_api.rb
@@ -27,7 +27,12 @@ module Proxy::DiscoveryImage
         log_halt 500, "Unable to parse kexec JSON input: #{body_data}"
       end
       args = ["--debug", "--force"]
-      args << data['extra'] if data['extra']
+      extra = data['extra']
+      if extra && extra.is_a?(String)
+        args << extra
+      elsif extra && extra.is_a?(Array)
+        args.concat(extra)
+      end
       args << "--kexec-file-syscall" if is_secureboot
       args << "--append=#{data['append']}"
       args << "--initrd=/tmp/initrd.img"


### PR DESCRIPTION
It was appended as array (into array) which is causing problems when executing the command later on. This is a regression which slipped in, in my testing I did not use any "extra" arguments. I tested this, just read the code and merge for me thanks.